### PR TITLE
feat(historial): agregar endpoints para ver detalle de pedidos y gene…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,10 @@ dependencies {
 	implementation 'org.apache.poi:poi-ooxml:5.2.3'
 	implementation 'org.apache.poi:poi:5.2.3'
 
+	// Implementacion para Generara PDF del pedido
+	implementation 'com.github.librepdf:openpdf:1.3.30'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/utn/saborcito/El_saborcito_back/controllers/HistorialController.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/controllers/HistorialController.java
@@ -1,0 +1,42 @@
+package utn.saborcito.El_saborcito_back.controllers;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import utn.saborcito.El_saborcito_back.dto.PedidoDTO;
+import utn.saborcito.El_saborcito_back.dto.PedidoConRecetasDTO;
+import utn.saborcito.El_saborcito_back.services.HistorialService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/historial")
+@RequiredArgsConstructor
+public class HistorialController {
+
+    private final HistorialService historialService;
+
+    @GetMapping("/pedidos")
+    public ResponseEntity<List<PedidoDTO>> getHistorialPedidos() {
+        return ResponseEntity.ok(historialService.obtenerPedidosFinalizados());
+    }
+
+    @GetMapping("/pedidos/{id}/detalle-completo")
+    public ResponseEntity<PedidoConRecetasDTO> getPedidoConRecetas(@PathVariable Long id) {
+        return ResponseEntity.ok(historialService.obtenerDetalleCompletoPedido(id));
+    }
+    @GetMapping("/pedidos/{id}/pdf")
+    public ResponseEntity<byte[]> generarPDF(@PathVariable Long id) {
+        byte[] pdfBytes = historialService.generarPdfPedido(id);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        headers.setContentDispositionFormData("attachment", "pedido_" + id + ".pdf");
+
+        return new ResponseEntity<>(pdfBytes, headers, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/utn/saborcito/El_saborcito_back/dto/DetalleConRecetaDTO.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/dto/DetalleConRecetaDTO.java
@@ -1,0 +1,13 @@
+package utn.saborcito.El_saborcito_back.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class DetalleConRecetaDTO {
+    private String articuloNombre;
+    private Integer cantidad;
+    private Boolean esManufacturado;
+    private List<IngredienteDTO> receta;
+}

--- a/src/main/java/utn/saborcito/El_saborcito_back/dto/IngredienteDTO.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/dto/IngredienteDTO.java
@@ -1,0 +1,12 @@
+package utn.saborcito.El_saborcito_back.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class IngredienteDTO {
+    private String nombre;
+    private Integer cantidad;
+    private String unidadMedida;
+}

--- a/src/main/java/utn/saborcito/El_saborcito_back/dto/PedidoConRecetasDTO.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/dto/PedidoConRecetasDTO.java
@@ -1,0 +1,14 @@
+package utn.saborcito.El_saborcito_back.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class PedidoConRecetasDTO {
+    private Long id;
+    private LocalDate fecha;
+    private String cliente;
+    private List<DetalleConRecetaDTO> detalles;
+}

--- a/src/main/java/utn/saborcito/El_saborcito_back/services/HistorialService.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/services/HistorialService.java
@@ -1,0 +1,110 @@
+package utn.saborcito.El_saborcito_back.services;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import utn.saborcito.El_saborcito_back.dto.*;
+import utn.saborcito.El_saborcito_back.models.ArticuloManufacturado;
+import utn.saborcito.El_saborcito_back.models.Pedido;
+import utn.saborcito.El_saborcito_back.repositories.PedidoRepository;
+import utn.saborcito.El_saborcito_back.mappers.PedidoMapper;
+import com.lowagie.text.*;
+import com.lowagie.text.pdf.PdfWriter;
+
+import java.io.ByteArrayOutputStream;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HistorialService {
+
+    private final PedidoRepository pedidoRepository;
+    private final PedidoMapper pedidoMapper;
+
+    public List<PedidoDTO> obtenerPedidosFinalizados() {
+        List<String> estados = List.of("LISTO", "FACTURADO");
+        return pedidoRepository.findByEstadoNombreIn(estados)
+                .stream()
+                .map(pedidoMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public PedidoConRecetasDTO obtenerDetalleCompletoPedido(Long id) {
+        Pedido pedido = pedidoRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Pedido no encontrado"));
+
+        PedidoConRecetasDTO dto = new PedidoConRecetasDTO();
+        dto.setId(pedido.getId());
+        dto.setFecha(pedido.getFechaPedido());
+        dto.setCliente(pedido.getCliente().getNombre() + " " + pedido.getCliente().getApellido());
+
+        List<DetalleConRecetaDTO> detalles = pedido.getDetalles().stream()
+                .map(det -> {
+                    DetalleConRecetaDTO detalleDTO = new DetalleConRecetaDTO();
+                    detalleDTO.setArticuloNombre(det.getArticulo().getDenominacion());
+                    detalleDTO.setCantidad(det.getCantidad());
+
+                    if (det.getArticulo() instanceof ArticuloManufacturado manufacturado) {
+                        detalleDTO.setEsManufacturado(true);
+
+                        List<IngredienteDTO> receta = manufacturado.getArticuloManufacturadoDetalles().stream()
+                                .map(ing -> new IngredienteDTO(
+                                        ing.getArticuloInsumo().getDenominacion(),
+                                        ing.getCantidad(),
+                                        ing.getArticuloInsumo().getUnidadMedida().getDenominacion()
+                                ))
+                                .collect(Collectors.toList());
+
+                        detalleDTO.setReceta(receta);
+                    } else {
+                        detalleDTO.setEsManufacturado(false);
+                        detalleDTO.setReceta(List.of());
+                    }
+
+                    return detalleDTO;
+                })
+                .collect(Collectors.toList());
+
+        dto.setDetalles(detalles);
+        return dto;
+    }
+    public byte[] generarPdfPedido(Long id) {
+        PedidoConRecetasDTO dto = obtenerDetalleCompletoPedido(id);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Document document = new Document();
+        PdfWriter.getInstance(document, baos);
+
+        document.open();
+
+        Font titleFont = new Font(Font.HELVETICA, 16, Font.BOLD);
+        Font subFont = new Font(Font.HELVETICA, 12, Font.BOLD);
+        Font textFont = new Font(Font.HELVETICA, 10);
+
+        document.add(new Paragraph("Detalle de Pedido #" + dto.getId(), titleFont));
+        document.add(new Paragraph("Cliente: " + dto.getCliente(), textFont));
+        document.add(new Paragraph("Fecha: " + dto.getFecha(), textFont));
+        document.add(new Paragraph(" "));
+
+        for (DetalleConRecetaDTO det : dto.getDetalles()) {
+            document.add(new Paragraph("Producto: " + det.getArticuloNombre(), subFont));
+            document.add(new Paragraph("Cantidad: " + det.getCantidad(), textFont));
+            if (Boolean.TRUE.equals(det.getEsManufacturado())) {
+                document.add(new Paragraph("Receta:", textFont));
+                for (IngredienteDTO ing : det.getReceta()) {
+                    document.add(new Paragraph(
+                            "- " + ing.getNombre() + " (" + ing.getCantidad() + " " + ing.getUnidadMedida() + ")",
+                            textFont
+                    ));
+                }
+            }
+            document.add(new Paragraph(" "));
+        }
+
+        document.close();
+        return baos.toByteArray();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,4 @@ web.cors.allowed-origins=${CORS_ALLOWED_ORIGINS}
 
 logging.level.org.springframework.security=${SPRING_SECURITY_LOG_LEVEL}
 spring.websecurity.debug=${WEB_SECURITY_DEBUG}
+debug=true


### PR DESCRIPTION
…rar PDF con recetas

funcionalidad completa para el módulo de Historial de Pedidos, permitiendo:

Listar pedidos finalizados (estados LISTO o FACTURADO).

Obtener el detalle completo de un pedido, incluyendo:

Productos pedidos

Recetas asociadas (si el artículo es manufacturado)

Generar y descargar un PDF del pedido con toda su información.

📦 Cambios principales
📁 Nuevos endpoints:
GET /api/historial/pedidos → Lista de pedidos finalizados

GET /api/historial/pedidos/{id}/detalle-completo → Detalle con recetas

GET /api/historial/pedidos/{id}/pdf → PDF generado desde backend (OpenPDF)

📁 Nuevas clases DTO:
PedidoConRecetasDTO

DetalleConRecetaDTO

IngredienteDTO

📁 Nuevos componentes backend:
HistorialService.java

HistorialController.java

📚 Tecnologías usadas
Librería openpdf para generación de PDF

MapStruct y servicios existentes para mapear recetas sin duplicar lógica

PDF con estructura clara y datos completos