### PR TITLE
 Fix: Unificación de lógica de cálculo de totales en informes estadísticos

### DIFF
--- a/src/main/java/utn/saborcito/El_saborcito_back/config/DataInitializer.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/config/DataInitializer.java
@@ -1312,28 +1312,28 @@
 //                         .build());
 //             }
 //
-             //  Verificación: listar y mostrar entidades para probar interacciones
-//              System.out.println("=== Verificación de datos cargados ===");
-//              System.out.println("Paises: " + paisRepo.findAll());
-//              System.out.println("Provincias: " + provinciaRepo.findAll());
-//              System.out.println("Localidades: " + localidadRepo.findAll());
-//              System.out.println("Usuarios: " + usuarioRepo.findAll());
-//              System.out.println("Empresas: " + empresaRepo.findAll());
-//              System.out.println("Domicilios: " + domicilioRepo.findAll());
-//              System.out.println("Sucursales: " + sucursalRepo.findAll());
-//              System.out.println("UnidadMedida: " + unidadMedidaRepo.findAll());
-//              System.out.println("Categorias: " + categoriaRepo.findAll());
-//              System.out.println("Imagenes: " + imagenRepo.findAll());
-//              System.out.println("Insumos: " + articuloInsumoRepo.findAll());
-//              System.out.println("Manufacturados: " + articuloManufacturadoRepo.findAll());
-//              System.out.println("Detalles Manufacturado: " + amdRepo.findAll());
-//              System.out.println("Promociones: " + promocionRepo.findAll());
-//              System.out.println("Clientes: " + clienteRepo.findAll());
-//              System.out.println("Pedidos: " + pedidoRepo.findAll());
-//              System.out.println("DetallePedido: " + detallePedidoRepo.findAll());
-//              System.out.println("Facturas: " + facturaRepo.findAll());
-//              System.out.println("Datos MercadoPago: " + datosMPRepo.findAll());
-//              System.out.println("Horarios: " + horarioRepo.findAll());
+//             //  Verificación: listar y mostrar entidades para probar interacciones
+////              System.out.println("=== Verificación de datos cargados ===");
+////              System.out.println("Paises: " + paisRepo.findAll());
+////              System.out.println("Provincias: " + provinciaRepo.findAll());
+////              System.out.println("Localidades: " + localidadRepo.findAll());
+////              System.out.println("Usuarios: " + usuarioRepo.findAll());
+////              System.out.println("Empresas: " + empresaRepo.findAll());
+////              System.out.println("Domicilios: " + domicilioRepo.findAll());
+////              System.out.println("Sucursales: " + sucursalRepo.findAll());
+////              System.out.println("UnidadMedida: " + unidadMedidaRepo.findAll());
+////              System.out.println("Categorias: " + categoriaRepo.findAll());
+////              System.out.println("Imagenes: " + imagenRepo.findAll());
+////              System.out.println("Insumos: " + articuloInsumoRepo.findAll());
+////              System.out.println("Manufacturados: " + articuloManufacturadoRepo.findAll());
+////              System.out.println("Detalles Manufacturado: " + amdRepo.findAll());
+////              System.out.println("Promociones: " + promocionRepo.findAll());
+////              System.out.println("Clientes: " + clienteRepo.findAll());
+////              System.out.println("Pedidos: " + pedidoRepo.findAll());
+////              System.out.println("DetallePedido: " + detallePedidoRepo.findAll());
+////              System.out.println("Facturas: " + facturaRepo.findAll());
+////              System.out.println("Datos MercadoPago: " + datosMPRepo.findAll());
+////              System.out.println("Horarios: " + horarioRepo.findAll());
 //         };
 //     }
 // }

--- a/src/main/java/utn/saborcito/El_saborcito_back/controllers/SucursalController.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/controllers/SucursalController.java
@@ -17,6 +17,8 @@ import utn.saborcito.El_saborcito_back.dto.ProductoRankingConResumenDTO;
 import utn.saborcito.El_saborcito_back.dto.ProductoRankingDTO;
 import utn.saborcito.El_saborcito_back.dto.SucursalDTO;
 import utn.saborcito.El_saborcito_back.services.SucursalService;
+import utn.saborcito.El_saborcito_back.dto.PedidoGananciaDetalleDTO;
+import utn.saborcito.El_saborcito_back.dto.PedidoCostoDetalleDTO;
 
 
 import java.io.IOException;
@@ -124,6 +126,40 @@ public class SucursalController {
         return service.getRankingProductos(desde, hasta);
     }
 
+    @GetMapping("/detalle-ganancias")
+    public List<PedidoGananciaDetalleDTO> getDetalleGanancias(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta
+    ) {
+        return service.getDetalleGanancias(desde, hasta);
+    }
+
+    @GetMapping("/detalle-costos")
+    public List<PedidoCostoDetalleDTO> getDetalleCostos(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta
+    ) {
+        return service.getDetalleCostos(desde, hasta);
+    }
+
+    @GetMapping("/exportar-detalle-ganancias-excel")
+    public void exportarDetalleGananciasExcel(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            HttpServletResponse response
+    ) throws IOException {
+        service.exportarDetalleGananciasExcel(desde, hasta, response);
+    }
+
+    @GetMapping("/exportar-detalle-costos-excel")
+    public void exportarDetalleCostosExcel(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            HttpServletResponse response
+    ) throws IOException {
+        service.exportarDetalleCostosExcel(desde, hasta, response);
+    }
+
 
     @GetMapping
     public List<SucursalDTO> getAll() {
@@ -149,4 +185,6 @@ public class SucursalController {
     public void delete(@PathVariable Long id) {
         service.delete(id);
     }
+
+
 }

--- a/src/main/java/utn/saborcito/El_saborcito_back/dto/PedidoCostoDetalleDTO.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/dto/PedidoCostoDetalleDTO.java
@@ -1,0 +1,16 @@
+package utn.saborcito.El_saborcito_back.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PedidoCostoDetalleDTO {
+    private Long idPedido;
+    private LocalDate fechaPedido;
+    private Double totalCosto;
+}

--- a/src/main/java/utn/saborcito/El_saborcito_back/dto/PedidoGananciaDetalleDTO.java
+++ b/src/main/java/utn/saborcito/El_saborcito_back/dto/PedidoGananciaDetalleDTO.java
@@ -1,0 +1,16 @@
+package utn.saborcito.El_saborcito_back.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PedidoGananciaDetalleDTO {
+    private Long idPedido;
+    private LocalDate fechaPedido;
+    private Double total;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,6 @@ web.cors.allowed-origins=${CORS_ALLOWED_ORIGINS}
 logging.level.org.springframework.security=${SPRING_SECURITY_LOG_LEVEL}
 spring.websecurity.debug=${WEB_SECURITY_DEBUG}
 debug=true
-
 #Configuracion de token JWT
 jwt.secret=${JWT_SECRET}
 jwt.expiration=${JWT_EXPIRATION}


### PR DESCRIPTION

Descripción:
Problema Identificado
Inconsistencia de datos entre módulos de informes debido a diferentes lógicas de cálculo: getMovimientos(): Usaba pedido.getTotal() directamente y pedido.calcularCostoTotal() para costos getRankingClientes(): Calculaba totales desde detalles cuando pedido.total era null Base de datos: Contenía valores precalculados en total_costo que no se utilizaban Causa Raíz
Duplicación de lógica: SucursalService replicaba cálculos que ya existían en CalculadoraPedidoService Inconsistencia: Diferentes métodos aplicaban diferentes criterios para totales null Desaprovechamiento: Campo total_costo de BD no se utilizaba correctamente Solución Implementada
1. Unificación de lógica en getMovimientos() Apply to MovimientosM...
2. Simplificación de lógica en getRankingClientes() Apply to MovimientosM...
Beneficios Obtenidos
✅ Consistencia de datos: Ambos métodos usan la misma lógica ✅ Aprovechamiento de BD: Usa valores precalculados en total_costo ✅ Eliminación de duplicación: Remueve lógica redundante ✅ Mejor rendimiento: Evita cálculos innecesarios
✅ Mantenibilidad: Una sola fuente de verdad para cálculos Archivos Modificados
utn/saborcito/El_saborcito_back/services/SucursalService.java Validación
Costos: Ahora suma correctamente $9,300 (5000 + 4300) desde total_costo Ingresos: Mantiene $15,800 desde total válidos
Ranking: Totales consistentes con movimientos monetarios Notas Técnicas
Se mantiene CalculadoraPedidoService para futuros cálculos si es necesario Los campos null en BD se tratan como 0 de forma consistente Logging mantenido para debugging